### PR TITLE
Removeredisfallback

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,16 +24,16 @@ app.secret_key = os.environ["FLASK_SECRET_KEY"]
 
 # Cookie-konfiguration for maksimal sikkerhed
 app.config.update({
-    'SESSION_COOKIE_SECURE': True,
+    'SESSION_COOKIE_SECURE': False,  # True for HTTPS
     'SESSION_COOKIE_HTTPONLY': True,
     'SESSION_COOKIE_SAMESITE': 'Strict',
     'PERMANENT_SESSION_LIFETIME': timedelta(minutes=30),
     'SESSION_COOKIE_NAME': 'viento_session',
     'SESSION_TYPE': 'redis',
     'SESSION_REDIS': redis.Redis(
-        host=os.environ.get("REDIS_HOST", "localhost"),
-        port=int(os.environ.get("REDIS_PORT", 6379)),
-        db=0
+        host=os.environ.get("REDIS_HOST"), 
+        port=int(os.environ.get("REDIS_PORT")), 
+        db=0 # Redis database number
     )
 })
 

--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ app.secret_key = os.environ["FLASK_SECRET_KEY"]
 
 # Cookie-konfiguration for maksimal sikkerhed
 app.config.update({
-    'SESSION_COOKIE_SECURE': False,  # True for HTTPS
+    'SESSION_COOKIE_SECURE': True,  # True for HTTPS
     'SESSION_COOKIE_HTTPONLY': True,
     'SESSION_COOKIE_SAMESITE': 'Strict',
     'PERMANENT_SESSION_LIFETIME': timedelta(minutes=30),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,6 @@ services:
   redis:
     image: redis:latest
     container_name: fulldemo_redis_exam
-    ports:
-      - 6379:6379
     volumes:
       - redis_data:/data
 


### PR DESCRIPTION
Jeg har fjernet fallback values for redis i app.py.
Jeg har unexposed porten i docker-compose.yml, da det var overfladisk (fordi redis kun skal kommunikere internt i containeren).

Env filen forbliver den samme.